### PR TITLE
Introduced owned Difference

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -12,11 +12,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
 
       # make sure all code has been formatted with rustfmt
       - name: check rustfmt
@@ -39,10 +38,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
       - run: cargo fetch
       - name: cargo test build
         # Note the use of release here means longer compile time, but much
@@ -57,10 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
       - run: cargo fetch
       - name: cargo publish check
         run: cargo publish --dry-run
@@ -73,11 +70,10 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        override: true
     - run: cargo fetch
     - run: cargo publish
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Expose the types `Difference`, `Path` and `Key`.
+- New function `try_assert_json_matches()` which returns a `Vec<Difference>` instead of a error message, allow user to do further processing. 
+
 ## [0.2.1] - 2025-03-11
 
 ### Fixed


### PR DESCRIPTION
Here's a prototype of my approach, 
The main thing I want is to keep the original macros and the no_panic function as fast as before.

When I was trying to make a `DifferenceBuf` like PathBuf and String in std, I realized they are struct but not a memory window like &str, so I can never create a `Difference<'_>`  cheaply from it

So I take `DifferenceBuf` as a public variant of `Difference<'_>`, it's used only for the case when we want to return a struct to crate user, and since it's the only struct user can see (`Difference<'_>` is still private), I rename `Difference<'_>` to `DifferenceRef<'_>`, and let `DifferenceBuf`-> `Difference`

The disadvantage is that I probably added too much code to achieve it and renamed the original `assert_json_matches_no_panic()` to `assert_json_matches_no_panic_to_string()`, which makes it a breaking change. I can't really figure out a good name for the new function.

Please let me know what you think about it. Thanks!

