### PR TITLE
Add second macro forms with custom panic messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- All `json_assert` macros now have second forms, where a custom panic message
+  can be provided.
+
 ## [0.3.1] - 2025-06-08
 
 ### Fixed

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -371,3 +371,81 @@ fn can_fail_ignore_array_sorting_with_strict_comparisons() {
     let config = Config::new(CompareMode::Strict).consider_array_sorting(false);
     assert_json_matches!(&actual, &expected, &config);
 }
+
+#[test]
+fn assert_json_contains_can_fail_with_message() {
+    let result = std::panic::catch_unwind(|| {
+        assert_json_contains!(
+            container: json!({ "a": { "b": true } }),
+            contained: json!({ "a": { "b": false } }),
+            "The {} assert failed because of {}",
+            "'contains'",
+            "'reasons'"
+        );
+    });
+
+    assert!(result.is_err());
+
+    let error = result.unwrap_err();
+    let msg = error.downcast_ref::<String>().unwrap();
+    assert!(msg.contains("The 'contains' assert failed because of 'reasons'"));
+}
+
+#[test]
+fn assert_json_include_can_fail_with_message() {
+    let result = std::panic::catch_unwind(|| {
+        assert_json_include!(
+            actual: json!({ "a": { "b": true } }),
+            expected: json!({ "a": { "b": false } }),
+            "The {} assert failed because of {}",
+            "'include'",
+            "'reasons'"
+        );
+    });
+
+    assert!(result.is_err());
+
+    let error = result.unwrap_err();
+    let msg = error.downcast_ref::<String>().unwrap();
+    assert!(msg.contains("The 'include' assert failed because of 'reasons'"));
+}
+
+#[test]
+fn assert_json_eq_can_fail_with_message() {
+    let result = std::panic::catch_unwind(|| {
+        assert_json_eq!(
+            json!({ "a": { "b": true } }),
+            json!({ "a": { "b": false } }),
+            "The {} assert failed because of {}",
+            "'eq'",
+            "'reasons'"
+        );
+    });
+
+    assert!(result.is_err());
+
+    let error = result.unwrap_err();
+    let msg = error.downcast_ref::<String>().unwrap();
+    assert!(msg.contains("The 'eq' assert failed because of 'reasons'"));
+}
+
+#[test]
+fn assert_json_matches_can_fail_with_message() {
+    let config = Config::new(CompareMode::Strict).consider_array_sorting(false);
+    let result = std::panic::catch_unwind(|| {
+        assert_json_matches!(
+            json!({ "a": { "b": true } }),
+            json!({ "a": { "b": false } }),
+            &config,
+            "The {} assert failed because of {}",
+            "'matches'",
+            "'reasons'"
+        );
+    });
+
+    assert!(result.is_err());
+
+    let error = result.unwrap_err();
+    let msg = error.downcast_ref::<String>().unwrap();
+    assert!(msg.contains("The 'matches' assert failed because of 'reasons'"));
+}


### PR DESCRIPTION
All assert macros have been extended with second forms that take a custom panic message that's displayed before the default error messages. The custom error messages can be used to provide more context about why a test failed or, e.g, to disambiguate between multiple tests that are perhaps performed in a loop.

Issue: #2